### PR TITLE
Add grid cell CSS rule

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -36,5 +36,10 @@ body {
 }
 
 .grid-cell {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 100px;
+  cursor: pointer;
   border: 2px solid gray;
 }


### PR DESCRIPTION
Added a CSS rule for grid cell so that the user's tokens will be centered and sized correctly for each cell selection. The sizing may change once I finalize the styling of the user tokens and overall theme of the board.