### PR TITLE
Change display header and player indicators

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,11 +9,14 @@
 </head>
 <body>
   <section class="left-scoreboard">
-    <h1 class="player1-header">Player 1</h1>
-    <p class ="player1-win-counter"># Wins</p>
+    <h1 class="playerX-header">Player 1</h1>
+    <p class ="playerX-win-counter"># Wins</p>
   </section>
+
   <main class="game-board">
-    <h2 class="player-turn-tracker">It's [player's] turn!</h2>
+    <section class="display-player">
+      <p>It's player <span class="display-player playerX">X</span>'s turn!</p>
+    </section>
     <section class="grid-container">
       <div class="grid-cell"></div>
       <div class="grid-cell"></div>
@@ -25,10 +28,11 @@
       <div class="grid-cell"></div>
       <div class="grid-cell"></div>
     </section>
+
   </main>
   <section class="right-scoreboard">
-    <h3 class="player2-header">Player 2</h3>
-    <p class ="player2-win-counter"># Wins</p>
+    <h3 class="playerO-header">Player 2</h3>
+    <p class ="playerO-win-counter"># Wins</p>
   </section>
   <script src="./src/player.js"></script>
   <script src="./src/game.js"></script>

--- a/styles.css
+++ b/styles.css
@@ -12,17 +12,17 @@ body {
   border: 2px solid green;
 }
 
-.player1-header,
-.player2-header,
-.player1-win-counter,
-.player2-win-counter,
-.player-turn-tracker {
+.playerX-header,
+.playerO-header,
+.playerX-win-counter,
+.playerO-win-counter,
+.display-player {
   text-align: center;
   font-size: 40px;
   border: 2px solid magenta;
 }
 
-.player-turn-tracker {
+.display-player {
   margin-top: 80px;
 }
 


### PR DESCRIPTION
Since I'll be adjusting the player's indicator after each turn, I removed the h2 with the class "player-turn-tracker" and replaced it with a section. In the section, it now has a paragraph that contains a span so that I can replace the X for O and vice versa after each turn.

I'm not 100% sure that I'll get to the styling portion where I can use emoji's for the players, so I replaced "player1" and "player2" with "playerX" and "playerO" as to stick with a more traditional setup.

I updated the classes in the CSS file to align with the new player assignments.