### PR TITLE
Fix bug for check diagonal win function

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -63,7 +63,7 @@ class Game {
   };
 
   checkForDiagonalWin() {
-    if (this.board[0].token === this.currentPlayer.token && this.board[0].token === this.currentPlayer.token && this.board[8].token === this.currentPlayer.token ||
+    if (this.board[0].token === this.currentPlayer.token && this.board[4].token === this.currentPlayer.token && this.board[8].token === this.currentPlayer.token ||
     this.board[2].token === this.currentPlayer.token && this.board[4].token === this.currentPlayer.token && this.board[6].token === this.currentPlayer.token) {
       this.win = true;
     }


### PR DESCRIPTION
Found a bug on line 66 of the game.js file. Games that should be considered a draw where no one wins were displaying a win in the banner and increasing the player's scoreboard.

After review, I found that the `checkForDiagonalWin()` function was calculating a diagonal win if the token matched on indexes [0][0][8] when it should have been indexes [0][4][8]. Before changing the index, I played several games where I was able to recreate the bug.

I changed the index to the correct sequence and now the game is working properly.